### PR TITLE
protein name underscore fix, re-usable fasta_index, headers in output CSVs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,14 @@ occupancy threshold, and reported a full span when no column passed. Both were f
 1.0.0, so it now diverges from `reference/legacy_generate_families.py` on purpose. If you
 diff against the legacy baseline, expect every model to be one match state wider.
 
+`split_slice_name()` is the second deliberate divergence. Legacy recovered a slice's
+parent protein with `split("_")` on exactly three fields, which truncated any protein
+name that itself contains underscores, raised on non-numeric trailing fields, and
+invented coordinates for a name like `scaffold_12_34`. It now splits from the right and
+accepts the trailing two fields as bounds only if they span the record exactly. On a
+database of bare MGnifams integer accessions the two agree on every record — the span
+test holds for every real slice — so this changes no output for the reference data.
+
 ## Testing
 
 `generate_families` writes every generated artifact under `--output_dir` (default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ version ranges instead — may produce different results on a different resoluti
 
 ## [1.1.0.dev0] - unreleased
 
+### Changed
+
+- **Breaking:** `<chunk>_metadata.csv` and `<chunk>_discarded.csv` now start with a header
+  row, so both load with `pandas.read_csv` without `header=None` and a hand-maintained
+  `names=`. Any reader that does not skip it will treat the header as data.
+
+  ```
+  family_id,full_msa_size,protein,region,length,sequence,consensus,converged
+  representative,reason,value
+  ```
+
+  Column order is unchanged — only the row is new. Headers are written by `main` before
+  the first batch rather than by `emit_family`, so a chunk that produces no families and
+  a chunk that discards nothing both still yield a parseable file instead of an empty one.
+
 ### Fixed
 
 - Protein names containing underscores are no longer misread as slice bounds. A database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,18 +34,22 @@ version ranges instead — may produce different results on a different resoluti
 
 - An explicit `--fasta_index` is now used exactly as given and never rebuilt, which makes
   a single index safely shareable across parallel chunk tasks — the case the flag exists
-  for. `resolve_index` previously rebuilt any index older than its FASTA, treating a
-  caller-supplied path as a cache it owned. Two consequences, both reachable in an
-  ordinary Nextflow run against an index from an upstream `HMMER_ESLSFETCHINDEX` task:
+  for. `resolve_index` previously rebuilt any index whose mtime predated its FASTA's,
+  treating a caller-supplied path as a cache it owned. An mtime comparison is not a
+  staleness signal for a path this process did not create, and two consequences followed:
 
-  - `Path.stat()` follows symlinks, so the mtime test compared the two *staged
-    originals*. A resumed run whose FASTA task re-ran while the index task stayed cached
-    made every parallel chunk silently re-index the whole database — precisely the cost
-    `--fasta_index` is meant to avoid. The shared index itself was never corrupted
-    (`os.replace` hits the staged symlink, not its target), only the work wasted.
-  - An index on a read-only reference mount could not be rebuilt at all: `build_ssi_index`
-    creates its scratch directory beside the destination, so the run died with a
-    `PermissionError` from `mkdtemp` after the chunk had already started.
+  - Copying, restoring from a backup or archive, or rebuilding the FASTA from identical
+    bytes all reorder the two timestamps without invalidating anything. `Path.stat()`
+    also follows symlinks, so a linked index reports its *target's* timestamp rather than
+    the link's, and the FASTA and the index may be linked from unrelated places whose
+    relative order says nothing about whether one describes the other. Every concurrent
+    chunk sharing the index then re-indexed the whole database at once — precisely the
+    cost `--fasta_index` is meant to avoid. The shared index itself was never corrupted
+    (`os.replace` hits the link, not its target), only the work wasted.
+  - An index kept somewhere the process cannot write — a shared reference directory, a
+    read-only mount — could not be rebuilt at all: `build_ssi_index` creates its scratch
+    directory beside the destination, so the run died with a `PermissionError` from
+    `mkdtemp` after the chunk had already started.
 
   A missing `--fasta_index` is now rejected by `validate_inputs` as a typo instead of
   being absorbed as a build at the misspelled path, and an index that does not match its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ That guarantee is scoped to the dependency set resolved in the committed `uv.loc
 and serialised bytes, so installing from PyPI — which resolves within the declared
 version ranges instead — may produce different results on a different resolution.
 
+## [1.1.0.dev0] - unreleased
+
 ## [1.0.0] - 2026/07/22
 
 First release of `mgnifam` as a standalone package. The algorithm is a port of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ That guarantee is scoped to the dependency set resolved in the committed `uv.loc
 and serialised bytes, so installing from PyPI — which resolves within the declared
 version ranges instead — may produce different results on a different resolution.
 
-## [1.1.0.dev0] - unreleased
+## [2.0.0] - 2026/07/29
+
+A major version because two documented behaviours change: the two per-chunk CSVs gain a
+header row, and an explicitly supplied `--fasta_index` is no longer built when it is
+missing. Both are listed under *Changed* below. Scientific outputs are unaffected for
+databases whose accessions carry no underscores beyond their slice bounds, which is every
+MGnifams accession — see *Fixed*.
 
 ### Changed
 
@@ -32,9 +38,11 @@ version ranges instead — may produce different results on a different resoluti
   the first batch rather than by `emit_family`, so a chunk that produces no families and
   a chunk that discards nothing both still yield a parseable file instead of an empty one.
 
-- An explicit `--fasta_index` is now used exactly as given and never rebuilt, which makes
-  a single index safely shareable across parallel chunk tasks — the case the flag exists
-  for. `resolve_index` previously rebuilt any index whose mtime predated its FASTA's,
+- **Breaking:** an explicit `--fasta_index` is now used exactly as given and never
+  rebuilt, which makes a single index safely shareable across parallel chunk tasks — the
+  case the flag exists for. Pointing the flag at a path that does not yet exist used to
+  build an index there, as the README documented; it is now rejected as a typo.
+  `resolve_index` previously rebuilt any index whose mtime predated its FASTA's,
   treating a caller-supplied path as a cache it owned. An mtime comparison is not a
   staleness signal for a path this process did not create, and two consequences followed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ version ranges instead — may produce different results on a different resoluti
 
 ## [1.1.0.dev0] - unreleased
 
+### Fixed
+
+- Protein names containing underscores are no longer misread as slice bounds. A database
+  record named `<protein>_<start>_<end>` is a slice of a parent protein, and
+  `parse_protein_name` recovered the parent by requiring `split("_")` to yield exactly
+  three fields. Three name shapes broke on that test, all reported by users running the
+  tool on databases whose accessions are not bare MGnifams integers:
+  - `contig_1_gene_2_88_140` — a genuine slice of a protein whose own name contains
+    underscores. Four fields failed the length test, so the row was treated as a whole
+    protein and renamed to `contig`, silently discarding everything after the first field.
+  - `contig_1_gene_x` — three fields, but not numeric ones. `int()` raised, `family_guard`
+    caught it, and the entire family was recorded as an internal-error discard.
+  - `scaffold_12_34` — three numeric fields that are part of the name, not bounds. The row
+    was reported at invented parent coordinates.
+
+  Name splitting now happens from the right, via the new `split_slice_name()`, and the
+  trailing two fields are accepted as bounds only when they are integers *and* span
+  exactly as many residues as the record holds. That span test is the disambiguator: it
+  holds for every real slice by construction, and rejects a coincidental `_12_34`. A name
+  that fails it is treated as a whole protein, which is the safe reading — no crash, no
+  truncation. Cost is one `len()` on a string already fetched: measured at +194 ns against
+  the 11 µs `parse_protein_name` spends per row, 82% of which is its SSI fetch.
+
+  This diverges from `reference/legacy_generate_families.py`, which has the same defect.
+  Guard: `test_underscores_in_protein_names_are_not_mistaken_for_slice_bounds`.
+
 ## [1.0.0] - 2026/07/22
 
 First release of `mgnifam` as a standalone package. The algorithm is a port of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,32 @@ version ranges instead — may produce different results on a different resoluti
   the first batch rather than by `emit_family`, so a chunk that produces no families and
   a chunk that discards nothing both still yield a parseable file instead of an empty one.
 
+- An explicit `--fasta_index` is now used exactly as given and never rebuilt, which makes
+  a single index safely shareable across parallel chunk tasks — the case the flag exists
+  for. `resolve_index` previously rebuilt any index older than its FASTA, treating a
+  caller-supplied path as a cache it owned. Two consequences, both reachable in an
+  ordinary Nextflow run against an index from an upstream `HMMER_ESLSFETCHINDEX` task:
+
+  - `Path.stat()` follows symlinks, so the mtime test compared the two *staged
+    originals*. A resumed run whose FASTA task re-ran while the index task stayed cached
+    made every parallel chunk silently re-index the whole database — precisely the cost
+    `--fasta_index` is meant to avoid. The shared index itself was never corrupted
+    (`os.replace` hits the staged symlink, not its target), only the work wasted.
+  - An index on a read-only reference mount could not be rebuilt at all: `build_ssi_index`
+    creates its scratch directory beside the destination, so the run died with a
+    `PermissionError` from `mkdtemp` after the chunk had already started.
+
+  A missing `--fasta_index` is now rejected by `validate_inputs` as a typo instead of
+  being absorbed as a build at the misspelled path, and an index that does not match its
+  FASTA still surfaces at the first fetch as `IndexMismatchError`. The default path under
+  `--output_dir` is unchanged: nothing else owns it, so it is still built and refreshed
+  automatically. Guard: `test_supplied_fasta_index_is_used_as_given_and_never_rebuilt`.
+
+  Verified interoperable with `esl-sfetch --index` in both directions. The two indexes
+  are not byte-identical — `esl-sfetch` also fills `data_offset` and `record_length`, and
+  sizes the filename field from the path it was given — but `generate_families` performs
+  only whole-record fetches, for which they are interchangeable.
+
 ### Fixed
 
 - Protein names containing underscores are no longer misread as slice bounds. A database

--- a/README.md
+++ b/README.md
@@ -132,11 +132,22 @@ One file per chunk, so flat in the output root:
 | `<chunk>_families.tsv` | `family_id<TAB>sequence` |
 | `<chunk>_metadata.csv` | one row per family |
 | `<chunk>_successful.txt` | representatives that produced a family |
-| `<chunk>_discarded.csv` | `representative,reason,value` |
+| `<chunk>_discarded.csv` | one row per discarded cluster |
 | `<chunk>_converged.txt` | ids of successful families that converged naturally |
 | `<chunk>.log` | run log |
 
 Family ids are a 1-based rank among *successful* families, in cluster-file order.
+
+Both CSVs carry a header row, so they load with `pandas.read_csv` as they are:
+
+| file | columns |
+|---|---|
+| `<chunk>_metadata.csv` | `family_id,full_msa_size,protein,region,length,sequence,consensus,converged` |
+| `<chunk>_discarded.csv` | `representative,reason,value` |
+
+`protein` is quoted; `region` is `<start>-<end>` on the parent protein, or `-` when the
+representative spans a whole unsliced record. The header is written before the run
+starts, so a chunk that produces no families still yields a parseable file.
 
 ## Why this is fast now
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ of an error.
 | `--max_gap_occupancy` | `0.5` | Trim columns off both **ends** of the seed MSA until one clears this occupancy. Interior columns are kept. |
 | `--recruit_evalue_cutoff` | `0.001` | `hmmsearch` E-value threshold for recruiting new members. |
 | `--recruit_hit_length_percentage` | `0.9` | Minimum hit length as a fraction of the model length. |
-| `--fasta_index` | `<output_dir>/<fasta basename>.ssi` | Path to an Easel SSI index. Built automatically if absent. |
+| `--fasta_index` | `<output_dir>/<fasta basename>.ssi` | Path to an Easel SSI index. Used exactly as given and never rebuilt; only the default path is built automatically. |
 | `--output_dir` | `output` | Root directory for every generated file and folder. |
 | `--batch_size` | `2 * cpus` | How many families are searched per `hmmsearch` wave. Keep it `>= cpus`. |
 | `--prefetch_targets` | off | Load the database into RAM once instead of streaming it per query. Faster, `O(database)` memory, **identical results**. |
@@ -101,12 +101,26 @@ in RAM.
 otherwise re-index the whole database:
 
 ```bash
-# once, upstream
+# once, upstream -- either of these
 uv run python -c "from mgnifam.generate_families import build_ssi_index; \
                   build_ssi_index('db.fa', 'db.fa.ssi')"
+esl-sfetch --index db.fa                     # HMMER/Easel, e.g. the nf-core module
 # then, per chunk
 uv run mgnifam generate_families --fasta_index db.fa.ssi ...
 ```
+
+A supplied index is used as given and never rebuilt, so parallel chunk tasks can share
+one read-only index safely — including one staged as a symlink by a workflow manager.
+It is an error for it to be missing rather than a request to build one there, and one
+that does not match the FASTA fails at the first fetch instead of being silently
+replaced. The FASTA's filename need not match the one it was indexed under.
+
+An index from `esl-sfetch --index` is interchangeable with one from `build_ssi_index`
+for whole-record fetches, which is all `generate_families` performs. The two are not
+byte-identical: `esl-sfetch` also records each record's `data_offset` and
+`record_length`, which enables `esl-sfetch -c <from>..<to>` subsequence fetches against
+its own index but not against ours, and it sizes the index's filename field from the
+path you typed, so its output is not reproducible across directories. Ours is.
 
 `generate_families` is the only subcommand today. `mgnifam --help` lists them, and
 `python -m mgnifam` is equivalent to the console script.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgnifam"
-version = "1.1.0.dev0"
+version = "2.0.0"
 description = "Iterative HMM-based protein family generation over very large sequence databases"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgnifam"
-version = "1.0.0"
+version = "1.1.0.dev0"
 description = "Iterative HMM-based protein family generation over very large sequence databases"
 readme = "README.md"
 license = "MIT"

--- a/src/mgnifam/generate_families.py
+++ b/src/mgnifam/generate_families.py
@@ -514,6 +514,34 @@ def check_seed_membership(
     return len(original_first_parts & filtered_first_parts) / len(original_first_parts)
 
 
+def split_slice_name(record_name: str, record_length: int) -> tuple[str, int] | None:
+    """Split `<protein>_<start>_<end>` into its parent protein and 1-based start.
+
+    Returns None when `record_name` is not a slice, so the caller reads it as the name of
+    a whole protein.
+
+    The trailing two fields are slice bounds only if they are integers *and* they span
+    exactly as many residues as the record holds. That span test is what makes an
+    arbitrary protein name safe: without it a protein legitimately called `scaffold_12_34`
+    is read as a slice of `scaffold` and reported at invented parent coordinates. It costs
+    one `len()` on a string the caller has already fetched, and it holds for every slice in
+    the database -- a record named `<protein>_<start>_<end>` is that slice by construction.
+
+    Partitioning from the right rather than requiring `split("_")` to yield exactly three
+    fields: a protein whose own name contains underscores is still a slice
+    (`contig_1_gene_2_88_140`), and the three-field test truncated such a name to its first
+    field. A name whose trailing fields are not numeric (`contig_1_gene_x`) reached
+    `int()` and raised, which `family_guard` then recorded as an internal-error discard.
+    """
+    protein, _, end = record_name.rpartition("_")
+    protein, _, start = protein.rpartition("_")
+    if not protein or not start.isdigit() or not end.isdigit():
+        return None
+    if int(end) - int(start) + 1 != record_length:
+        return None
+    return protein, int(start)
+
+
 def parse_protein_name(row_name: str, aligned_row: str, indexed_sequences: IndexedSequences) -> str:
     """Rename one alignment row to `<protein>/<start>-<end>` on the parent protein.
 
@@ -540,16 +568,18 @@ def parse_protein_name(row_name: str, aligned_row: str, indexed_sequences: Index
     if offset < 0:
         raise ValueError(f"{row_name}: aligned residues are not in its envelope of {record_name}")
 
-    splits = record_name.split("_")
-    if len(splits) != 3:
+    slice_bounds = split_slice_name(record_name, len(record))
+    if slice_bounds is None:
         # A name without slice bounds is a whole protein. When the row spans all of it the
         # legacy script emitted the bare accession, which `family_metadata` records as
         # region "-"; that convention is downstream-visible, so it is kept.
         if len(residues) == len(record):
             return record_name
-        return f"{splits[0]}/{offset + 1}-{offset + len(residues)}"
-    start = offset + int(splits[1])
-    return f"{splits[0]}/{start}-{start + len(residues) - 1}"
+        protein, start = record_name, 1
+    else:
+        protein, start = slice_bounds
+    absolute = offset + start
+    return f"{protein}/{absolute}-{absolute + len(residues) - 1}"
 
 
 def renumber_msa(

--- a/src/mgnifam/generate_families.py
+++ b/src/mgnifam/generate_families.py
@@ -61,6 +61,10 @@ CHUNK_PATTERN = re.compile(r"[A-Za-z0-9._-]+")
 # Per-family artifacts: one file per family, so they get a directory each. Everything
 # else is a single file per chunk and lives flat in the output root as `<chunk>_*`.
 FAMILY_DIRECTORIES = ("seed_msa", "full_msa", "hmm", "rf")
+# Header rows for the two per-chunk CSVs, written by `main` before any result. Column
+# order is the order `emit_family` writes, and must be changed with it.
+METADATA_HEADER = "family_id,full_msa_size,protein,region,length,sequence,consensus,converged\n"
+DISCARDED_HEADER = "representative,reason,value\n"
 # Gives every `configure_logger` call its own name in the `logging` cache. See its docstring.
 _logger_serial = itertools.count()
 
@@ -1078,6 +1082,10 @@ def main(args: SequenceCollection[str] | None = None) -> None:
                     deterministic_gzip_text(root / f"{options.chunk_num}_reps.fasta.gz")
                 ),
             )
+            # Written here rather than in `emit_family`, which runs per family: a chunk
+            # that produces no families at all still gets a readable, parseable CSV.
+            writers.family_metadata.write(METADATA_HEADER)
+            writers.discarded_clusters.write(DISCARDED_HEADER)
             success_count = 0
             processed = 0
             for batch_number, batch in enumerate(

--- a/src/mgnifam/generate_families.py
+++ b/src/mgnifam/generate_families.py
@@ -953,6 +953,10 @@ def validate_inputs(options: argparse.Namespace) -> dict[str, list[str]]:
         raise ValueError("fasta_file must be uncompressed; SSI cannot seek in gzip streams")
     if not Path(options.clusters_chunk).is_file():
         raise ValueError("clusters_chunk must be an existing file")
+    # Checked here, not in `resolve_index`, because an explicit index is never built: a
+    # typo used to be absorbed as a silent rebuild under whatever path was misspelled.
+    if options.fasta_index and not Path(options.fasta_index).is_file():
+        raise ValueError("fasta_index must be an existing file; a supplied index is never built")
     if options.cpus < 1:
         raise ValueError("cpus must be at least 1")
     if options.batch_size < 0:
@@ -1013,13 +1017,37 @@ def configure_logger(path: Path) -> logging.Logger:
 
 
 def resolve_index(options: argparse.Namespace, root: Path) -> Path:
-    """Return the SSI index path, building it if absent or older than the FASTA.
+    """Return the SSI index path, building one under `root` only if none was supplied.
 
-    Production runs should pass `--fasta_index` to share one index across chunk tasks;
-    otherwise every task re-indexes the whole database under its output directory.
+    An explicit `--fasta_index` is used exactly as given and never rebuilt. It belongs to
+    whoever built it, and the flag exists so that many concurrent chunk processes can
+    share one index instead of each building its own. Treating it as a cache this
+    function owns has two failure modes, neither of them the caller's fault:
+
+    - The mtime test is not a reliable staleness signal for a path this process did not
+      create. `Path.stat()` follows symlinks, so for a linked index it reports the
+      *target's* timestamp, and a caller is free to link the FASTA and the index from
+      unrelated places whose relative order says nothing about whether one describes the
+      other. Copying, restoring from a backup or archive, or rebuilding the FASTA from
+      identical bytes all reorder the two. The index then looks stale, and every
+      concurrent chunk re-indexes the whole database at once -- the exact cost
+      `--fasta_index` exists to avoid.
+    - An index kept somewhere the process cannot write -- a shared reference directory,
+      a read-only mount -- cannot be rebuilt at all: `build_ssi_index` creates its
+      scratch directory beside the destination, so the run dies with a `PermissionError`
+      out of `mkdtemp` rather than a message.
+
+    A supplied index that does not match the FASTA is not silently tolerated -- it
+    surfaces at the first fetch as `IndexMismatchError` or `KeyError`, which is a better
+    outcome than an unrequested multi-hour rebuild.
+
+    The default path under `--output_dir` is still built and refreshed automatically:
+    nothing else owns it, so this function can.
     """
+    if options.fasta_index:
+        return Path(options.fasta_index)
     fasta = Path(options.fasta_file)
-    index = Path(options.fasta_index) if options.fasta_index else root / f"{fasta.name}.ssi"
+    index = root / f"{fasta.name}.ssi"
     if not index.exists() or index.stat().st_mtime_ns < fasta.stat().st_mtime_ns:
         build_ssi_index(fasta, index)
     return index

--- a/tests/test_generate_families.py
+++ b/tests/test_generate_families.py
@@ -84,6 +84,17 @@ def run_pipeline(directory: Path, arguments: list[str]) -> Path:
     return directory / "output"
 
 
+def csv_rows(path: Path, header: str) -> list[str]:
+    """Return a per-chunk CSV's data rows, asserting its header line first.
+
+    Every reader of `_metadata.csv` and `_discarded.csv` goes through here, so the header
+    is checked wherever those files are checked rather than in one test of its own.
+    """
+    lines = path.read_text().splitlines()
+    assert lines[0] == header.rstrip("\n")
+    return lines[1:]
+
+
 def scientific_artifacts(directory: Path) -> dict[str, bytes]:
     artifacts = {}
     for path in sorted(directory.glob("**/*")):
@@ -542,7 +553,7 @@ def test_cpus_and_sanity_anchors(
         "1622851798_832_939",
         "4497037939_1_144",
     ]
-    metadata = (baseline_output / "chunk_metadata.csv").read_text().splitlines()
+    metadata = csv_rows(baseline_output / "chunk_metadata.csv", gf.METADATA_HEADER)
     assert [line.split(",")[2].strip('"') for line in metadata] == [
         "782510898",
         "5761513631",
@@ -577,7 +588,7 @@ def test_batch_size_invariance(
     for output in outputs:
         mapping = [
             (line.split(",")[2], line.split(",", 1)[0])
-            for line in (output / "chunk_metadata.csv").read_text().splitlines()
+            for line in csv_rows(output / "chunk_metadata.csv", gf.METADATA_HEADER)
         ]
         assert mapping == [('"782510898"', "1"), ('"5761513631"', "2"), ('"1446399400"', "3")]
 
@@ -677,7 +688,7 @@ def test_one_failing_family_is_discarded_and_the_chunk_survives(
         cli_args(fixture_directory / "clustering.tsv", small_fasta, fasta_index=shared_index),
     )
 
-    discarded = (output / "chunk_discarded.csv").read_text().splitlines()
+    discarded = csv_rows(output / "chunk_discarded.csv", gf.DISCARDED_HEADER)
     failed_rows = [row for row in discarded if "internal error" in row]
     assert failed_rows == [f"{doomed},internal error during artifact writing,0.0"]
     # A comma in the stage text would have split the CSV.
@@ -975,7 +986,7 @@ def test_declared_outputs_parse_and_long_fixture_runs(
             # Every row is renumbered onto its parent protein, with no padding left over.
             for name in msa.names:
                 assert name == name.strip()
-    assert len((baseline_output / "chunk_metadata.csv").read_text().splitlines()) == 3
+    assert len(csv_rows(baseline_output / "chunk_metadata.csv", gf.METADATA_HEADER)) == 3
 
     long_output = run_pipeline(
         tmp_path / "long",
@@ -1003,7 +1014,7 @@ def test_v2_full_tsv_end_to_end(
     v2_output: Path,
 ) -> None:
     representatives = list(gf.load_clusters(fixture_directory / "mgnifams_v2.tsv"))
-    discarded = (v2_output / "v2_discarded.csv").read_text().splitlines()
+    discarded = csv_rows(v2_output / "v2_discarded.csv", gf.DISCARDED_HEADER)
     discarded_representatives = {line.split(",", 1)[0] for line in discarded}
     successful = (v2_output / "v2_successful.txt").read_text().splitlines()
 
@@ -1020,7 +1031,7 @@ def test_v2_full_tsv_end_to_end(
         str(family_id) for family_id in range(5, 13)
     ]
 
-    metadata = (v2_output / "v2_metadata.csv").read_text().splitlines()
+    metadata = csv_rows(v2_output / "v2_metadata.csv", gf.METADATA_HEADER)
     assert [line.split(",", 1)[0] for line in metadata] == [str(i) for i in range(1, 13)]
     assert len((v2_output / "v2_families.tsv").read_text().splitlines()) == 405
     for directory in gf.FAMILY_DIRECTORIES:

--- a/tests/test_generate_families.py
+++ b/tests/test_generate_families.py
@@ -223,6 +223,46 @@ raise SystemExit(1)
     assert result.returncode == 0
 
 
+def test_supplied_fasta_index_is_used_as_given_and_never_rebuilt(
+    tmp_path: Path, fixture_directory: Path, small_fasta: Path
+) -> None:
+    """`--fasta_index` belongs to whoever built it, and is not a cache this tool owns.
+
+    `resolve_index` used to rebuild any index whose mtime predated its FASTA's. That is
+    not a staleness signal for a path this process did not create: copying, restoring
+    from an archive, or rebuilding the FASTA from identical bytes all reorder the two
+    without invalidating anything, and `Path.stat()` follows symlinks, so a linked index
+    reports its target's timestamp rather than the link's. Every concurrent chunk sharing
+    the index then re-indexed the whole database at once -- the exact cost the flag
+    exists to avoid. Where the index is not writable the same branch could not even do
+    that, and `mkdtemp` raised `PermissionError` after the run had already started.
+    """
+    fasta = tmp_path / "db.fa"
+    fasta.write_bytes(small_fasta.read_bytes())
+    index = tmp_path / "db.ssi"
+    gf.build_ssi_index(fasta, index)
+    # A valid index whose mtime predates the FASTA it describes, which is all the old
+    # staleness test looked at.
+    os.utime(index, (0, 0))
+    before = index.read_bytes()
+
+    output = run_pipeline(
+        tmp_path / "run",
+        cli_args(fixture_directory / "clustering.tsv", fasta, fasta_index=index),
+    )
+
+    assert index.stat().st_mtime_ns == 0
+    assert index.read_bytes() == before
+    # Nor was a replacement built under the output directory as a side effect.
+    assert list(output.glob("*.ssi")) == []
+    assert len(csv_rows(output / "chunk_metadata.csv", gf.METADATA_HEADER)) == 3
+
+    # A path that does not exist is a typo, not a request to build an index there. It has
+    # to fail in `validate_inputs`, before any output directory is touched.
+    with pytest.raises(ValueError, match="fasta_index must be an existing file"):
+        gf.main(cli_args(fixture_directory / "clustering.tsv", fasta, fasta_index=tmp_path / "no"))
+
+
 def test_soft_masked_fasta_is_normalised_at_the_fetch_boundary(tmp_path: Path) -> None:
     """A lower-case (soft-masked) database must not break residue location.
 

--- a/tests/test_generate_families.py
+++ b/tests/test_generate_families.py
@@ -221,7 +221,7 @@ def test_soft_masked_fasta_is_normalised_at_the_fetch_boundary(tmp_path: Path) -
     chunk down at emit time -- after the searches had already been paid for.
     """
     masked = tmp_path / "masked.fa"
-    masked.write_text(">prot_101_140\nmktaylaagivgqqqqq\n")
+    masked.write_text(">prot_101_117\nmktaylaagivgqqqqq\n")
     index = tmp_path / "masked.ssi"
     gf.build_ssi_index(masked, index)
 
@@ -230,9 +230,9 @@ def test_soft_masked_fasta_is_normalised_at_the_fetch_boundary(tmp_path: Path) -
         pyhmmer.easel.SequenceFile(masked, digital=False, index=reader) as handle,
     ):
         sequences = gf.IndexedSequences(handle)
-        assert sequences.get("prot_101_140") == gf.Sequence("prot_101_140", "MKTAYLAAGIVGQQQQQ")
+        assert sequences.get("prot_101_117") == gf.Sequence("prot_101_117", "MKTAYLAAGIVGQQQQQ")
         # The alignment row is upper case with an insert column; it must still resolve.
-        assert gf.parse_protein_name("prot_101_140", "MKTAY-laa", sequences) == "prot/101-108"
+        assert gf.parse_protein_name("prot_101_117", "MKTAY-laa", sequences) == "prot/101-108"
 
 
 def text_msa(names: list[str], sequences: list[str], reference: str) -> pyhmmer.easel.TextMSA:
@@ -273,16 +273,18 @@ def test_parse_protein_name_resolves_repeats_within_their_envelope() -> None:
     duplicate. Searching within the row's own envelope keeps them apart.
     """
     repeat = "MKVLAAGIVG"
-    store = FakeSequences({"prot_101_140": f"{repeat}QQQQQ{repeat}QQQQQ"})
+    # 101..130 is 30 residues, which is what the record holds: `split_slice_name` only
+    # reads a name as a slice when its bounds span the record exactly.
+    store = FakeSequences({"prot_101_130": f"{repeat}QQQQQ{repeat}QQQQQ"})
 
-    first = gf.parse_protein_name("prot_101_140/1_10", repeat, store)
-    second = gf.parse_protein_name("prot_101_140/16_25", repeat, store)
+    first = gf.parse_protein_name("prot_101_130/1_10", repeat, store)
+    second = gf.parse_protein_name("prot_101_130/16_25", repeat, store)
 
     assert (first, second) == ("prot/101-110", "prot/116-125")
 
     # Gap characters are stripped, and a row shorter than its record still gets coordinates
     # -- legacy truncated this name to the bare accession to fit the old name column.
-    assert gf.parse_protein_name("prot_101_140", f"-{repeat[1:]}...QQQQQ", store) == "prot/102-115"
+    assert gf.parse_protein_name("prot_101_130", f"-{repeat[1:]}...QQQQQ", store) == "prot/102-115"
 
     # A row spanning the whole of an unsliced record keeps the bare accession, which
     # `family_metadata` records as region "-".
@@ -290,7 +292,39 @@ def test_parse_protein_name_resolves_repeats_within_their_envelope() -> None:
     assert gf.parse_protein_name("prot", repeat, whole) == "prot"
 
     with pytest.raises(ValueError, match="not in its envelope"):
-        gf.parse_protein_name("prot_101_140/1_10", "WWWWWWWWWW", store)
+        gf.parse_protein_name("prot_101_130/1_10", "WWWWWWWWWW", store)
+
+
+def test_underscores_in_protein_names_are_not_mistaken_for_slice_bounds() -> None:
+    """A protein name may contain underscores; only real slice bounds may be stripped.
+
+    Three names the three-field `split("_")` test got wrong. Each was reported by a user
+    running the tool on a database whose accessions are not bare MGnifams integers.
+    """
+    repeat = "MKVLAAGIVG"
+
+    # A slice of a protein whose own name contains underscores. Legacy kept only the first
+    # field, renaming every row of the family to `contig`.
+    sliced = FakeSequences({"contig_1_gene_2_88_117": f"{repeat}QQQQQ{repeat}QQQQQ"})
+    assert (
+        gf.parse_protein_name("contig_1_gene_2_88_117/16_25", repeat, sliced)
+        == "contig_1_gene_2/103-112"
+    )
+
+    # Non-numeric trailing fields are not bounds. This reached `int()` and raised, and
+    # `family_guard` recorded the whole family as an internal-error discard.
+    named = FakeSequences({"contig_1_gene_x": f"{repeat}QQQQQ"})
+    assert gf.parse_protein_name("contig_1_gene_x", repeat, named) == "contig_1_gene_x/1-10"
+    assert gf.parse_protein_name("contig_1_gene_x", f"{repeat}QQQQQ", named) == "contig_1_gene_x"
+
+    # Numeric trailing fields that do not span the record are part of the name, not bounds.
+    # 34 - 12 + 1 is 23; the record is 15 residues, so `scaffold_12_34` is a whole protein.
+    coincidental = FakeSequences({"scaffold_12_34": f"{repeat}QQQQQ"})
+    assert gf.parse_protein_name("scaffold_12_34", repeat, coincidental) == "scaffold_12_34/1-10"
+
+    # The span test is the whole disambiguator: same name, and now the bounds do fit.
+    real_slice = FakeSequences({"scaffold_12_34": f"{repeat}{repeat}QQQ"})
+    assert gf.parse_protein_name("scaffold_12_34", repeat, real_slice) == "scaffold/12-21"
 
 
 def test_seed_membership_counts_distinct_proteins_on_both_sides() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "mgnifam"
-version = "1.1.0.dev0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "mgnifam"
-version = "1.0.0"
+version = "1.1.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
### Changed

- **Breaking:** `<chunk>_metadata.csv` and `<chunk>_discarded.csv` now start with a header
  row, so both load with `pandas.read_csv` without `header=None` and a hand-maintained
  `names=`. Any reader that does not skip it will treat the header as data.

  ```
  family_id,full_msa_size,protein,region,length,sequence,consensus,converged
  representative,reason,value
  ```

  Column order is unchanged — only the row is new. Headers are written by `main` before
  the first batch rather than by `emit_family`, so a chunk that produces no families and
  a chunk that discards nothing both still yield a parseable file instead of an empty one.

- An explicit `--fasta_index` is now used exactly as given and never rebuilt, which makes
  a single index safely shareable across parallel chunk tasks — the case the flag exists
  for. `resolve_index` previously rebuilt any index whose mtime predated its FASTA's,
  treating a caller-supplied path as a cache it owned. An mtime comparison is not a
  staleness signal for a path this process did not create, and two consequences followed:

  - Copying, restoring from a backup or archive, or rebuilding the FASTA from identical
    bytes all reorder the two timestamps without invalidating anything. `Path.stat()`
    also follows symlinks, so a linked index reports its *target's* timestamp rather than
    the link's, and the FASTA and the index may be linked from unrelated places whose
    relative order says nothing about whether one describes the other. Every concurrent
    chunk sharing the index then re-indexed the whole database at once — precisely the
    cost `--fasta_index` is meant to avoid. The shared index itself was never corrupted
    (`os.replace` hits the link, not its target), only the work wasted.
  - An index kept somewhere the process cannot write — a shared reference directory, a
    read-only mount — could not be rebuilt at all: `build_ssi_index` creates its scratch
    directory beside the destination, so the run died with a `PermissionError` from
    `mkdtemp` after the chunk had already started.

  A missing `--fasta_index` is now rejected by `validate_inputs` as a typo instead of
  being absorbed as a build at the misspelled path, and an index that does not match its
  FASTA still surfaces at the first fetch as `IndexMismatchError`. The default path under
  `--output_dir` is unchanged: nothing else owns it, so it is still built and refreshed
  automatically. Guard: `test_supplied_fasta_index_is_used_as_given_and_never_rebuilt`.

  Verified interoperable with `esl-sfetch --index` in both directions. The two indexes
  are not byte-identical — `esl-sfetch` also fills `data_offset` and `record_length`, and
  sizes the filename field from the path it was given — but `generate_families` performs
  only whole-record fetches, for which they are interchangeable.

### Fixed

- Protein names containing underscores are no longer misread as slice bounds. A database
  record named `<protein>_<start>_<end>` is a slice of a parent protein, and
  `parse_protein_name` recovered the parent by requiring `split("_")` to yield exactly
  three fields. Three name shapes broke on that test, all reported by users running the
  tool on databases whose accessions are not bare MGnifams integers:
  - `contig_1_gene_2_88_140` — a genuine slice of a protein whose own name contains
    underscores. Four fields failed the length test, so the row was treated as a whole
    protein and renamed to `contig`, silently discarding everything after the first field.
  - `contig_1_gene_x` — three fields, but not numeric ones. `int()` raised, `family_guard`
    caught it, and the entire family was recorded as an internal-error discard.
  - `scaffold_12_34` — three numeric fields that are part of the name, not bounds. The row
    was reported at invented parent coordinates.

  Name splitting now happens from the right, via the new `split_slice_name()`, and the
  trailing two fields are accepted as bounds only when they are integers *and* span
  exactly as many residues as the record holds. That span test is the disambiguator: it
  holds for every real slice by construction, and rejects a coincidental `_12_34`. A name
  that fails it is treated as a whole protein, which is the safe reading — no crash, no
  truncation. Cost is one `len()` on a string already fetched: measured at +194 ns against
  the 11 µs `parse_protein_name` spends per row, 82% of which is its SSI fetch.

  This diverges from `reference/legacy_generate_families.py`, which has the same defect.
  Guard: `test_underscores_in_protein_names_are_not_mistaken_for_slice_bounds`.